### PR TITLE
Remove LogEditorSettings.Save method

### DIFF
--- a/Packages/UGF.Logs/Editor/LogBuildPreprocess.cs
+++ b/Packages/UGF.Logs/Editor/LogBuildPreprocess.cs
@@ -14,7 +14,7 @@ namespace UGF.Logs.Editor
         {
             BuildTargetGroup group = report.summary.platformGroup;
 
-            if (LogEditorSettings.Settings.TryGetSettings(group, out DefinesSettings settings) && settings.IncludeInBuild)
+            if (LogEditorSettings.PlatformSettings.TryGetSettings(group, out DefinesSettings settings) && settings.IncludeInBuild)
             {
                 DefinesBuildEditorUtility.ApplyDefinesAll(group, settings);
                 AssetDatabase.SaveAssets();

--- a/Packages/UGF.Logs/Editor/LogEditorSettings.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettings.cs
@@ -11,17 +11,17 @@ namespace UGF.Logs.Editor
     {
         public static bool EditorEnabled
         {
-            get { return m_settings.Data.EditorEnabled; }
+            get { return Settings.Data.EditorEnabled; }
             set
             {
-                m_settings.Data.EditorEnabled = value;
-                m_settings.SaveSettings();
+                Settings.Data.EditorEnabled = value;
+                Settings.SaveSettings();
             }
         }
 
-        public static PlatformSettings<DefinesSettings> Settings { get { return m_settings.Data.Settings; } }
+        public static PlatformSettings<DefinesSettings> PlatformSettings { get { return Settings.Data.Settings; } }
 
-        private static readonly CustomSettingsEditorPackage<LogEditorSettingsData> m_settings = new CustomSettingsEditorPackage<LogEditorSettingsData>
+        public static CustomSettingsEditorPackage<LogEditorSettingsData> Settings { get; } = new CustomSettingsEditorPackage<LogEditorSettingsData>
         (
             "UGF.Logs",
             "LogEditorSettings"
@@ -29,19 +29,14 @@ namespace UGF.Logs.Editor
 
         static LogEditorSettings()
         {
-            m_settings.Saved += OnSettingsChanged;
-            m_settings.Loaded += OnSettingsChanged;
-        }
-
-        public static void Save()
-        {
-            m_settings.SaveSettings();
+            Settings.Saved += OnSettingsChanged;
+            Settings.Loaded += OnSettingsChanged;
         }
 
         [SettingsProvider]
         private static SettingsProvider GetProvider()
         {
-            return new CustomSettingsProvider<LogEditorSettingsData>("Project/UGF/Logs", m_settings, SettingsScope.Project);
+            return new CustomSettingsProvider<LogEditorSettingsData>("Project/UGF/Logs", Settings, SettingsScope.Project);
         }
 
         private static void OnSettingsChanged(LogEditorSettingsData data)

--- a/Packages/UGF.Logs/Editor/LogEditorSettingsData.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettingsData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace UGF.Logs.Editor
 {
-    internal class LogEditorSettingsData : CustomSettingsData
+    public class LogEditorSettingsData : CustomSettingsData
     {
         [SerializeField] private bool m_editorEnabled = true;
         [SerializeField] private PlatformSettings<DefinesSettings> m_settings = new PlatformSettings<DefinesSettings>();

--- a/Packages/UGF.Logs/Editor/LogEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettingsDataEditor.cs
@@ -48,7 +48,7 @@ namespace UGF.Logs.Editor
 
         private void OnApplied(string groupName, BuildTargetGroup buildTargetGroup)
         {
-            if (LogEditorSettings.Settings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
+            if (LogEditorSettings.PlatformSettings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
             {
                 DefinesBuildEditorUtility.ApplyDefinesAll(buildTargetGroup, settings);
                 AssetDatabase.SaveAssets();
@@ -57,7 +57,7 @@ namespace UGF.Logs.Editor
 
         private void OnCleared(string groupName, BuildTargetGroup buildTargetGroup)
         {
-            if (LogEditorSettings.Settings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
+            if (LogEditorSettings.PlatformSettings.TryGetSettings(buildTargetGroup, out DefinesSettings settings))
             {
                 DefinesBuildEditorUtility.ClearDefinesAll(buildTargetGroup, settings);
                 AssetDatabase.SaveAssets();


### PR DESCRIPTION
- Remove `LogEditorSettings.Save` method, use `LogEditorSettings.Settings.SaveSettings` instead.
- Change `LogEditorSettingsData` class to be public.
- Change `LogEditorSettings.Settings` property name to `LogEditorSettings.PlatformSettings`.
- Change `CustomSettingsEditorPackage<LogEditorSettingsData>` instance to be public and accessible from `LogEditorSettings`.