### PR TITLE
Add logs formatting with attached exception

### DIFF
--- a/Assets/UGF.Logs.Runtime.Tests/TestLog.cs
+++ b/Assets/UGF.Logs.Runtime.Tests/TestLog.cs
@@ -60,6 +60,22 @@ namespace UGF.Logs.Runtime.Tests
             }
         }
 
+        [Test]
+        public void LogWithException()
+        {
+            try
+            {
+                throw new Exception("Test exception.");
+            }
+            catch (Exception exception)
+            {
+                Log.Info("Message.", exception, new
+                {
+                    argument = 10
+                });
+            }
+        }
+
         // [Test]
         // public void LogError()
         // {

--- a/Assets/UGF.Logs.Runtime.Tests/TestLog.cs
+++ b/Assets/UGF.Logs.Runtime.Tests/TestLog.cs
@@ -73,6 +73,8 @@ namespace UGF.Logs.Runtime.Tests
                 {
                     argument = 10
                 });
+
+                Log.Warning("Warning", exception);
             }
         }
 

--- a/Packages/UGF.Logs/Runtime/Log.cs
+++ b/Packages/UGF.Logs/Runtime/Log.cs
@@ -52,6 +52,13 @@ namespace UGF.Logs.Runtime
             Message(LogType.Log, message, arguments);
         }
 
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_INFO_DEFINE)]
+        public static void Info(string message, Exception exception, object arguments = null)
+        {
+            Message(LogType.Log, message, exception, arguments);
+        }
+
         /// <summary>
         /// Logs message as debug info with the specified message.
         /// </summary>
@@ -79,6 +86,13 @@ namespace UGF.Logs.Runtime
         public static void Debug(string message, object arguments)
         {
             Message(LogType.Log, message, arguments);
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        public static void Debug(string message, Exception exception, object arguments = null)
+        {
+            Message(LogType.Log, message, exception, arguments);
         }
 
         /// <summary>
@@ -110,6 +124,13 @@ namespace UGF.Logs.Runtime
             Message(LogType.Warning, message, arguments);
         }
 
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_WARNING_DEFINE)]
+        public static void Warning(string message, Exception exception, object arguments = null)
+        {
+            Message(LogType.Warning, message, exception, arguments);
+        }
+
         /// <summary>
         /// Logs message as error info with the specified message.
         /// </summary>
@@ -137,6 +158,13 @@ namespace UGF.Logs.Runtime
         public static void Error(string message, object arguments)
         {
             Message(LogType.Error, message, arguments);
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_ERROR_DEFINE)]
+        public static void Error(string message, Exception exception, object arguments = null)
+        {
+            Message(LogType.Error, message, exception, arguments);
         }
 
         /// <summary>
@@ -188,6 +216,18 @@ namespace UGF.Logs.Runtime
         public static void Message(LogType logType, string message, object arguments)
         {
             message = LogUtility.Format(message, arguments);
+
+            Message(logType, message);
+        }
+
+        public static void Message(LogType logType, string message, Exception exception, object arguments = null)
+        {
+            if (arguments != null)
+            {
+                message = LogUtility.Format(message, arguments);
+            }
+
+            message = LogUtility.Format(message, exception);
 
             Message(logType, message);
         }

--- a/Packages/UGF.Logs/Runtime/LogUtility.cs
+++ b/Packages/UGF.Logs/Runtime/LogUtility.cs
@@ -12,6 +12,21 @@ namespace UGF.Logs.Runtime
         public const string LOG_ERROR_DEFINE = "UGF_LOG_ERROR";
         public const string LOG_EXCEPTION_DEFINE = "UGF_LOG_EXCEPTION";
 
+        public static string Format(string message, Exception exception)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (exception == null) throw new ArgumentNullException(nameof(exception));
+
+            var builder = new StringBuilder(message);
+
+            builder.AppendLine();
+            builder.Append(exception);
+            builder.AppendLine();
+            builder.Append("--- End of attached exception ---");
+
+            return builder.ToString();
+        }
+
         /// <summary>
         /// Formats the specified object arguments with message.
         /// </summary>

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.test-framework": "1.1.20"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -34,7 +34,7 @@
       }
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -50,11 +50,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.2.1f1
+m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)


### PR DESCRIPTION
- Add `LogUtility.Format()` method to format message with attached exception.
- Add `Log` methods to log message with attached exception.