### PR TITLE
Add log handler to replace Unity references

### DIFF
--- a/Packages/UGF.Logs/Editor/LogEditorSettings.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettings.cs
@@ -41,7 +41,10 @@ namespace UGF.Logs.Editor
 
         private static void OnSettingsChanged(LogEditorSettingsData data)
         {
-            Log.Logger.logEnabled = data.EditorEnabled;
+            if (Log.Handler is ILogHandlerWithEnable handler)
+            {
+                handler.IsEnabled = data.EditorEnabled;
+            }
         }
     }
 }

--- a/Packages/UGF.Logs/Runtime/ILogHandler.cs
+++ b/Packages/UGF.Logs/Runtime/ILogHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace UGF.Logs.Runtime
+{
+    public interface ILogHandler
+    {
+        void Write(string tag, object value);
+    }
+}

--- a/Packages/UGF.Logs/Runtime/ILogHandler.cs.meta
+++ b/Packages/UGF.Logs/Runtime/ILogHandler.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 91577372c6ca4dd9bdd5cb28330024af
+timeCreated: 1610109317

--- a/Packages/UGF.Logs/Runtime/ILogHandlerWithEnable.cs
+++ b/Packages/UGF.Logs/Runtime/ILogHandlerWithEnable.cs
@@ -1,0 +1,7 @@
+﻿namespace UGF.Logs.Runtime
+{
+    public interface ILogHandlerWithEnable : ILogHandler
+    {
+        bool IsEnabled { get; set; }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/ILogHandlerWithEnable.cs.meta
+++ b/Packages/UGF.Logs/Runtime/ILogHandlerWithEnable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c45ed4f07eec459d9cd1ea8b5bdb18bd
+timeCreated: 1610110982

--- a/Packages/UGF.Logs/Runtime/Log.Deprecated.cs
+++ b/Packages/UGF.Logs/Runtime/Log.Deprecated.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.Logs.Runtime
+{
+    public static partial class Log
+    {
+        /// <summary>
+        /// Gets or sets logger to use. (Default is Unity Logger wrapper.)
+        /// </summary>
+        /// <remarks>
+        /// By default logger is wrapper around Unity Logger and can be controlled separately from it, such as enabled or filter properties.
+        /// </remarks>
+        [Obsolete("Logger has been deprecated. Use Handler instead.")]
+        public static ILogger Logger { get { return m_logger; } set { m_logger = value ?? throw new ArgumentNullException(nameof(Logger)); } }
+
+        private static ILogger m_logger = new Logger(UnityEngine.Debug.unityLogger);
+
+        /// <summary>
+        /// Logs message with the specified log type and message.
+        /// </summary>
+        /// <remarks>
+        /// Invocation of this method always included in build.
+        /// </remarks>
+        /// <param name="logType">The type of the log.</param>
+        /// <param name="message">The message.</param>
+        [Obsolete("Message with LogType has been deprecated. Use Message method with tag instead.")]
+        public static void Message(LogType logType, object message)
+        {
+            Message(logType.ToString(), message);
+        }
+
+        /// <summary>
+        /// Logs message with the specified log type, message and arguments.
+        /// </summary>
+        /// <remarks>
+        /// Invocation of this method always included in build.
+        /// </remarks>
+        /// <param name="logType">The type of the log.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="arguments">The dynamic arguments used to format with message.</param>
+        [Obsolete("Message with LogType has been deprecated. Use Message method with tag instead.")]
+        public static void Message(LogType logType, string message, object arguments)
+        {
+            Message(logType.ToString(), message, arguments);
+        }
+
+        [Obsolete("Message with LogType has been deprecated. Use Message method with tag instead.")]
+        public static void Message(LogType logType, string message, Exception exception, object arguments = null)
+        {
+            Message(logType.ToString(), message, exception, arguments);
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/Log.Deprecated.cs.meta
+++ b/Packages/UGF.Logs/Runtime/Log.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ee8189d0318f46808db881a70e79c0dc
+timeCreated: 1610110013

--- a/Packages/UGF.Logs/Runtime/Log.Unity.cs
+++ b/Packages/UGF.Logs/Runtime/Log.Unity.cs
@@ -1,0 +1,10 @@
+﻿namespace UGF.Logs.Runtime
+{
+    public static partial class Log
+    {
+        static Log()
+        {
+            Handler = new LogHandlerUnity(UnityEngine.Debug.unityLogger);
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/Log.Unity.cs.meta
+++ b/Packages/UGF.Logs/Runtime/Log.Unity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 18c0dc354b314b50aaa9ca9ffe282ee0
+timeCreated: 1610110097

--- a/Packages/UGF.Logs/Runtime/LogEnableScope.cs
+++ b/Packages/UGF.Logs/Runtime/LogEnableScope.cs
@@ -7,6 +7,7 @@ namespace UGF.Logs.Runtime
     /// </summary>
     public readonly struct LogEnableScope : IDisposable
     {
+        private readonly ILogHandlerWithEnable m_handler;
         private readonly bool m_enabled;
 
         /// <summary>
@@ -15,14 +16,26 @@ namespace UGF.Logs.Runtime
         /// <param name="enabled">The value to enable or disable logger.</param>
         public LogEnableScope(bool enabled)
         {
-            m_enabled = Log.Logger.logEnabled;
+            if (Log.Handler is ILogHandlerWithEnable handler)
+            {
+                m_handler = handler;
+                m_enabled = handler.IsEnabled;
 
-            Log.Logger.logEnabled = enabled;
+                handler.IsEnabled = enabled;
+            }
+            else
+            {
+                m_handler = null;
+                m_enabled = false;
+            }
         }
 
         public void Dispose()
         {
-            Log.Logger.logEnabled = m_enabled;
+            if (m_handler != null)
+            {
+                m_handler.IsEnabled = m_enabled;
+            }
         }
     }
 }

--- a/Packages/UGF.Logs/Runtime/LogFilterScope.cs
+++ b/Packages/UGF.Logs/Runtime/LogFilterScope.cs
@@ -8,6 +8,7 @@ namespace UGF.Logs.Runtime
     /// </summary>
     public readonly struct LogFilterScope : IDisposable
     {
+        private readonly LogHandlerUnity m_handler;
         private readonly LogType m_filterLogType;
 
         /// <summary>
@@ -16,14 +17,26 @@ namespace UGF.Logs.Runtime
         /// <param name="filterLogType">The type of the filter.</param>
         public LogFilterScope(LogType filterLogType)
         {
-            m_filterLogType = Log.Logger.filterLogType;
+            if (Log.Handler is LogHandlerUnity handler)
+            {
+                m_handler = handler;
+                m_filterLogType = handler.UnityLogger.filterLogType;
 
-            Log.Logger.filterLogType = filterLogType;
+                handler.UnityLogger.filterLogType = filterLogType;
+            }
+            else
+            {
+                m_handler = null;
+                m_filterLogType = LogType.Log;
+            }
         }
 
         public void Dispose()
         {
-            Log.Logger.filterLogType = m_filterLogType;
+            if (m_handler != null)
+            {
+                m_handler.UnityLogger.filterLogType = m_filterLogType;
+            }
         }
     }
 }

--- a/Packages/UGF.Logs/Runtime/LogHandlerBase.cs
+++ b/Packages/UGF.Logs/Runtime/LogHandlerBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace UGF.Logs.Runtime
+{
+    public abstract class LogHandlerBase : ILogHandler
+    {
+        public void Write(string tag, object value)
+        {
+            if (string.IsNullOrEmpty(tag)) throw new ArgumentException("Value cannot be null or empty.", nameof(tag));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+        }
+
+        protected abstract void OnWrite(string tag, object value);
+    }
+}

--- a/Packages/UGF.Logs/Runtime/LogHandlerBase.cs.meta
+++ b/Packages/UGF.Logs/Runtime/LogHandlerBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d1904f43f6234d8fb5054cfd71cd4bc8
+timeCreated: 1610109459

--- a/Packages/UGF.Logs/Runtime/LogHandlerConsole.cs
+++ b/Packages/UGF.Logs/Runtime/LogHandlerConsole.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace UGF.Logs.Runtime
+{
+    public class LogHandlerConsole : LogHandlerBase
+    {
+        protected override void OnWrite(string tag, object value)
+        {
+            Console.WriteLine($"{tag}: {value}");
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/LogHandlerConsole.cs.meta
+++ b/Packages/UGF.Logs/Runtime/LogHandlerConsole.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d2e71655d203449d9d7a6e84e8d5e55f
+timeCreated: 1610110117

--- a/Packages/UGF.Logs/Runtime/LogHandlerScope.cs
+++ b/Packages/UGF.Logs/Runtime/LogHandlerScope.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace UGF.Logs.Runtime
+{
+    public readonly struct LogHandlerScope : IDisposable
+    {
+        private readonly ILogHandler m_handler;
+
+        public LogHandlerScope(ILogHandler handler)
+        {
+            m_handler = Log.Handler;
+
+            Log.Handler = handler;
+        }
+
+        public void Dispose()
+        {
+            Log.Handler = m_handler;
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/LogHandlerScope.cs.meta
+++ b/Packages/UGF.Logs/Runtime/LogHandlerScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 712962ab5c11471b8ba4e100cbbbc9d3
+timeCreated: 1610111532

--- a/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs
+++ b/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.Logs.Runtime
+{
+    public class LogHandlerUnity : LogHandlerBase, ILogHandlerWithEnable
+    {
+        public ILogger UnityLogger { get; }
+        public bool IsEnabled { get { return UnityLogger.logEnabled; } set { UnityLogger.logEnabled = value; } }
+
+        public LogHandlerUnity(ILogger unityLogger)
+        {
+            UnityLogger = unityLogger ?? throw new ArgumentNullException(nameof(unityLogger));
+        }
+
+        protected override void OnWrite(string tag, object value)
+        {
+            switch (tag)
+            {
+                case LogTags.INFO:
+                case LogTags.DEBUG:
+                case "Log":
+                {
+                    UnityLogger.Log(LogType.Log, value);
+                    break;
+                }
+                case LogTags.WARNING:
+                {
+                    UnityLogger.Log(LogType.Warning, value);
+                    break;
+                }
+                case LogTags.ERROR:
+                case "Assert":
+                {
+                    UnityLogger.Log(LogType.Error, value);
+                    break;
+                }
+                case LogTags.EXCEPTION:
+                {
+                    if (value is Exception exception)
+                    {
+                        UnityLogger.LogException(exception);
+                    }
+                    else
+                    {
+                        UnityLogger.Log(LogType.Exception, value.ToString());
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs.meta
+++ b/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2b46af555fa246fa92beaacc1e581bbb
+timeCreated: 1610109496

--- a/Packages/UGF.Logs/Runtime/LogScope.cs
+++ b/Packages/UGF.Logs/Runtime/LogScope.cs
@@ -6,6 +6,7 @@ namespace UGF.Logs.Runtime
     /// <summary>
     /// Represents local scope of the specified logger.
     /// </summary>
+    [Obsolete("LogScope with ILogger has been deprecated. Use LogHandlerScope instead.")]
     public readonly struct LogScope : IDisposable
     {
         private readonly ILogger m_logger;

--- a/Packages/UGF.Logs/Runtime/LogTags.cs
+++ b/Packages/UGF.Logs/Runtime/LogTags.cs
@@ -1,0 +1,11 @@
+﻿namespace UGF.Logs.Runtime
+{
+    public static class LogTags
+    {
+        public const string INFO = "Info";
+        public const string DEBUG = "Debug";
+        public const string WARNING = "Warning";
+        public const string ERROR = "Error";
+        public const string EXCEPTION = "Exception";
+    }
+}

--- a/Packages/UGF.Logs/Runtime/LogTags.cs.meta
+++ b/Packages/UGF.Logs/Runtime/LogTags.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e2af036e074545c3884a07ad814432bd
+timeCreated: 1610109101


### PR DESCRIPTION
- Add `ILogHandler` interface to implement any type of log handler.
- Add `LogTags` with major log tags constants, such as `Info`, `Warning`, `Error` and etc.
- Change `Log` methods to use `Handler` instead of `Logger` property.
- Deprecate `Log.Logger` property and `Log.Message` methods with _Unity_ `LogType` parameter, use `Handler` and `Message` methods with `tag` argument instead.
- Deprecate `LogScope` disposable structure. use `LogHandlerScope` instead.