### PR TITLE
Add unity logger custom tag write

### DIFF
--- a/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs
+++ b/Packages/UGF.Logs/Runtime/LogHandlerUnity.cs
@@ -48,6 +48,11 @@ namespace UGF.Logs.Runtime
 
                     break;
                 }
+                default:
+                {
+                    UnityLogger.Log(tag, value);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
- Add logging with custom tag for `LogHandlerUnity` when tag unknown. 