### PR TITLE
Fix auto creation of settings file on editor initialization

### DIFF
--- a/Packages/UGF.Logs/Editor/LogEditorSettings.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettings.cs
@@ -29,7 +29,10 @@ namespace UGF.Logs.Editor
 
         static LogEditorSettings()
         {
-            LogsUpdateEnable();
+            if (Settings.Exists())
+            {
+                LogsUpdateEnable();
+            }
 
             Settings.Saved += OnSettingsChanged;
             Settings.Loaded += OnSettingsChanged;


### PR DESCRIPTION
- Fix `LogEditorSettings` to check when settings file exists before change log handler enable state.