### PR TITLE
Change project settings root name

### DIFF
--- a/Packages/UGF.Logs/Editor/LogEditorSettings.cs
+++ b/Packages/UGF.Logs/Editor/LogEditorSettings.cs
@@ -41,7 +41,7 @@ namespace UGF.Logs.Editor
         [SettingsProvider]
         private static SettingsProvider GetProvider()
         {
-            return new CustomSettingsProvider<LogEditorSettingsData>("Project/UGF/Logs", Settings, SettingsScope.Project);
+            return new CustomSettingsProvider<LogEditorSettingsData>("Project/Unity Game Framework/Logs", Settings, SettingsScope.Project);
         }
 
         private static void OnSettingsChanged(LogEditorSettingsData data)

--- a/Packages/UGF.Logs/package.json
+++ b/Packages/UGF.Logs/package.json
@@ -23,6 +23,6 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.defines": "2.1.2"
+    "com.ugf.defines": "2.1.4"
   }
 }

--- a/Packages/UGF.Logs/package.json
+++ b/Packages/UGF.Logs/package.json
@@ -2,8 +2,7 @@
   "name": "com.ugf.logs",
   "displayName": "UGF.Logs",
   "version": "5.1.3",
-  "unity": "2020.2",
-  "unityRelease": "2f1",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides utilities for conditional compiled logs.",
   "author": {
@@ -17,10 +16,7 @@
   "changelogUrl": "https://github.com/unity-game-framework/ugf-logs/blob/master/changelog.md",
   "licensesUrl": "https://github.com/unity-game-framework/ugf-logs/blob/master/license",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@unity-game-framework"
-  },
-  "bintray": {
-    "registry": "https://api.bintray.com/content/unity-game-framework/public"
+    "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
     "com.ugf.defines": "2.1.4"

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.24"
   },
   "scopedRegistries": [
     {
       "name": "Unity Game Framework",
-      "url": "https://api.bintray.com/npm/unity-game-framework/public",
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default",
       "scopes": [
         "com.ugf"
       ]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
       "version": "2.1.2",
@@ -17,14 +17,14 @@
         "com.ugf.customsettings": "3.4.0",
         "com.ugf.editortools": "1.10.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
       "version": "1.10.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
       "version": "file:UGF.Logs",
@@ -42,16 +42,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.3",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.24",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,26 +1,27 @@
 {
   "dependencies": {
     "com.ugf.customsettings": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.editortools": "1.7.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.2",
+      "version": "2.1.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.editortools": "1.10.0"
+        "com.ugf.customsettings": "3.4.1",
+        "com.ugf.editortools": "1.11.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -31,7 +32,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.defines": "2.1.2"
+        "com.ugf.defines": "2.1.4"
       }
     },
     "com.unity.ext.nunit": {

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
     m_Capabilities: 7
   - m_Id: scoped:Unity Game Framework
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_IsDefault: 0
@@ -38,14 +38,14 @@ MonoBehaviour:
     m_Original:
       m_Id: scoped:Unity Game Framework
       m_Name: Unity Game Framework
-      m_Url: https://api.bintray.com/npm/unity-game-framework/public
+      m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
       m_Scopes:
       - com.ugf
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_SelectedScopeIndex: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.2f1
-m_EditorVersionWithRevision: 2020.2.2f1 (068178b99f32)
+m_EditorVersion: 2020.3.9f1
+m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)


### PR DESCRIPTION
- Update project to Unity of `2020.3` version.
- Update package publish registry.
- Update dependencies: `com.ugf.defines` to `2.1.4` version.
- Change project settings root name to `Unity Game Framework`.