### PR TITLE
Fix log.logger property accessor

### DIFF
--- a/Packages/UGF.Logs/Runtime/Log.Unity.cs
+++ b/Packages/UGF.Logs/Runtime/Log.Unity.cs
@@ -1,0 +1,10 @@
+﻿namespace UGF.Logs.Runtime
+{
+    public static partial class Log
+    {
+        static Log()
+        {
+            m_logger = new LogHandled(new LogHandlerUnity());
+        }
+    }
+}

--- a/Packages/UGF.Logs/Runtime/Log.Unity.cs.meta
+++ b/Packages/UGF.Logs/Runtime/Log.Unity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 319f2a07e36e4139bd6658bda62cf01a
+timeCreated: 1638035636

--- a/Packages/UGF.Logs/Runtime/Log.cs
+++ b/Packages/UGF.Logs/Runtime/Log.cs
@@ -12,9 +12,24 @@ namespace UGF.Logs.Runtime
     /// </remarks>
     public static partial class Log
     {
-        public static ILog Logger { get { return m_logger; } set { m_logger = value ?? throw new ArgumentNullException(nameof(value)); } }
+        public static ILog Logger
+        {
+            get { return m_logger ?? throw new ArgumentException("Value not specified."); }
+            [Obsolete("Logger setter is deprecated. Use SetLogger method instead.")]
+            set { SetLogger(value); }
+        }
 
-        private static ILog m_logger = new LogHandled(new LogHandlerUnity());
+        private static ILog m_logger;
+
+        public static void SetLogger(ILog logger)
+        {
+            m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public static void ClearLogger()
+        {
+            m_logger = null;
+        }
 
         /// <summary>
         /// Logs message as info with the specified message.

--- a/Packages/UGF.Logs/Runtime/LogScope.cs
+++ b/Packages/UGF.Logs/Runtime/LogScope.cs
@@ -12,12 +12,12 @@ namespace UGF.Logs.Runtime
 
             m_log = Log.Logger;
 
-            Log.Logger = log;
+            Log.SetLogger(log);
         }
 
         public void Dispose()
         {
-            Log.Logger = m_log;
+            Log.SetLogger(m_log);
         }
     }
 }

--- a/Packages/UGF.Logs/package.json
+++ b/Packages/UGF.Logs/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.logs",
   "displayName": "UGF.Logs",
   "version": "5.2.0",
-  "unity": "2020.3",
+  "unity": "2021.2",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides utilities for conditional compiled logs.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.29"
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -52,7 +52,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.16f1
-m_EditorVersionWithRevision: 2020.3.16f1 (049d6eca3c44)
+m_EditorVersion: 2021.2.3f1
+m_EditorVersionWithRevision: 2021.2.3f1 (32358a8527b4)


### PR DESCRIPTION
- Update package _Unity_ version to `2021.2`.
- Add `Log.SetLogger()` and `ClearLogger()` methods to control current logger.
- Deprecate `Log.Logger` setter, use `Log.SetLogger()` method instead.